### PR TITLE
Fix Appendix Eqn Numbering + minor simplifications

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -1,12 +1,8 @@
-.PHONY: main clean help
+.PHONY: clean help
 
 
-# .tex --> .pdf via latexmk. 
-%.pdf: %.tex references.bib
-	latexmk -pdf -g $<
-
-
-main: main.pdf 
+main.pdf: *.tex utdiss.sty references.bib
+	latexmk -pdf -g main.tex
 
 clean:
 	latexmk -c

--- a/template/appendix-tips.tex
+++ b/template/appendix-tips.tex
@@ -1,16 +1,8 @@
 \chapter{Tips and Tricks}
 \label{appendix:tips}
 
-\begin{figure}
-    \centering
-    \layout*
-    \vspace{.75in}
-    \caption{Layout of the page setup.}
-    \label{figure:layout}
-\end{figure}
-
 \begin{itemize}
-\item The margin dimensions are set at the top of `utdiss.tex`. If you decide to change them, add \verb"\usepackage{layout}" to \texttt{config.tex} and use the \verb"\layout*" command in the body of the document to see a schematic of the page setup.
+\item The margin dimensions are set at the top of \texttt{utdiss.tex}. If you decide to change them, add \verb"\usepackage{layout}" to \texttt{config.tex} and use the \verb"\layout*" command in the body of the document to see a schematic of the page setup.
 See \Cref{figure:layout}.
 \index{layout}
 
@@ -26,3 +18,12 @@ Use \verb"\Cref{}" if you want to ensure that the first word is capitalized (e.g
 \end{align}
 To change how this looks, play with the \verb"\numberwithin{}{}" command in \texttt{config.tex} \textbf{and} the \verb"\numberwithin{}{}" command in \texttt{utdiss.sty} under \verb"\def\appendices".
 \end{itemize}
+
+\newpage
+\begin{figure}[t]
+    \centering
+    \layout*
+    \vspace{.75in}
+    \caption{Layout of the page setup.}
+    \label{figure:layout}
+\end{figure}

--- a/template/appendix-tips.tex
+++ b/template/appendix-tips.tex
@@ -18,4 +18,11 @@ See \Cref{figure:layout}.
 Instead of \verb"\ref{}" or \verb"\eqref{}", use \verb"\cref{}".
 Use \verb"\Cref{}" if you want to ensure that the first word is capitalized (e.g., `Figure').
 \index{commands!cref@\verb+\cref{}+}
+
+\item This is how a labeled equation looks in an appendix:
+\begin{align}
+    \frac{\textup{d}}{\textup{d}t}\widehat{\mathbf{q}}(t)
+    &= \mathbf{F}(\widehat{\mathbf{q}}(t), \mathbf{u}(t)).
+\end{align}
+To change how this looks, play with the \verb"\numberwithin{}{}" command in \texttt{config.tex} \textbf{and} the \verb"\numberwithin{}{}" command in \texttt{utdiss.sty} under \verb"\def\appendices".
 \end{itemize}

--- a/template/config.tex
+++ b/template/config.tex
@@ -14,7 +14,6 @@
 % \usepackage{draftwatermark}   % "DRAFT" watermark in background.
 
 % Packages used solely for the explanation in the template.
-\usepackage{blindtext}          % Nonsense text.
 \usepackage{layout}             % Draw the page layout with \layout*.
 \usepackage{url}                % Typesetting URLs.
 \usepackage{verbatim}           % Quote block of text verbatim.
@@ -26,27 +25,22 @@
 % \oneandonehalfspacing \oneandonehalfspacequote        % DEFAULT
 % \doublespacing \doublespacequote
 
-%% If there are 10 or more sections, 10 or more subsections for a section,
-%% etc., you need to adjust the Table of Contents with \longtocentry.
-% \longtocentry
-
-% Math ------------------------------------------------------------------------
+% Math environments -----------------------------------------------------------
 
 \theoremstyle{plain}
-\newtheorem{theorem}{Theorem}[chapter]
+\newtheorem{theorem}{Theorem}[chapter]                  % Number by chapter
 \newtheorem{corollary}[theorem]{Corollary}
 \newtheorem{lemma}[theorem]{Lemma}
 \newtheorem{proposition}[theorem]{Proposition}
 
 \theoremstyle{definition}
-\newtheorem{definition}{Definition}[chapter]
+\newtheorem{definition}[theorem]{Definition}
 
 \theoremstyle{remark}
-\newtheorem{remark}{Remark}[chapter]
+\newtheorem{remark}[theorem]{Remark}
 \newtheorem*{notation}{Notation}
 
-% Number equations and theorems by chapter (Theorem 2.1, 2.2, ...).
-% \numberwithin{theorem}{chapter}
+% Number equations by chapter (Theorem 2.1, 2.2, ...).
 \numberwithin{equation}{chapter}
 \crefformat{equation}{(#2#1#3)}
 

--- a/template/main.tex
+++ b/template/main.tex
@@ -17,7 +17,6 @@
 \documentclass[12pt]{report}
 \usepackage{utdiss}
 \input{config}
-\usepackage{eucal}
 
 % Author information ==========================================================
 \author{First Middle Last}                        % Author's full name.

--- a/template/utdiss.sty
+++ b/template/utdiss.sty
@@ -246,13 +246,13 @@
     \centerline{\large\bf Appendix}
     \vspace*{\fill}
 
-    \addcontentsline{toc}{chapter}{Appendix}  % <-
+    \addcontentsline{toc}{chapter}{Appendix}
 
     \setcounter{chapter}{0}
     \setcounter{section}{0}
     \def\@chapapp{\appendixname}
     \chap@or@app=2
-    }
+}
 
 \def\appendices{\clearpage
     \typeout{Appendices.}
@@ -263,13 +263,15 @@
     \centerline{\large\bf Appendices}
     \vspace*{\fill}
 
-    \addcontentsline{toc}{chapter}{Appendices}    % <-
+    \addcontentsline{toc}{chapter}{Appendices}
 
     \setcounter{chapter}{0}
     \setcounter{section}{0}
     \def\@chapapp{\appendixname}
     \chap@or@app=2
-    \def\thechapter{\Alph{chapter}}}
+    \def\thechapter{\Alph{chapter}}
+    \numberwithin{equation}{chapter}              % Equations (A.1), (A.2), ...
+}
 
 % Counters --------------------------------------------------------------------
 % Redefinition of \@part for using by \part


### PR DESCRIPTION
- Fixed `Makefile` dependencies in the recipe for `main.pdf`
- Added `\numberwithin{equation}{chapter}` to the definition of `\appendices`, otherwise Appendix A equations were (B.1), (B.2), ... instead of (A.1), (A.2), ....
- Removed a few imports that are not used in the template.
- Definitions / remarks now use the same counter as theorem environments.