### PR TITLE
Hyperlink support

### DIFF
--- a/template/chapter-examples.tex
+++ b/template/chapter-examples.tex
@@ -86,7 +86,7 @@ The \verb"table" environment takes an optional argument to indicate the position
 \end{table}
 
 Use \verb"\caption[short caption]{long caption}" to add a caption to the table.
-\index{caption@\verb"\caption{}"}
+\index{caption@\verb+\caption{}+}
 The \texttt{short caption} is used in the List of Tables
 \index{List of Tables@\emph{List of Tables}}%
 while the \texttt{long caption} appears in the actual text.
@@ -107,7 +107,7 @@ The \verb"figure" environment takes the same optional arguments as the \verb"tab
 \end{figure}
 
 Use \verb"\caption[short caption]{long caption}" to add a caption to the figure.
-\index{caption@\verb"\caption{}"}
+\index{caption@\verb+\caption{}+}
 The \texttt{short caption} is used in the List of Figures
 \index{List of Figures@\emph{List of Figures}}%
 while the \texttt{long caption} appears in the actual text.

--- a/template/chapter-usage.tex
+++ b/template/chapter-usage.tex
@@ -99,7 +99,7 @@ Some details:
 \end{itemize}
 
 The preamble concludes with \verb+\makeindex+.
-Leave that command there, even if you do not have an index as described in \ref{sec:usage:index}
+Leave that command there, even if you do not have an index as described in \Cref{sec:usage:index}
 
 \subsection{Modifications for Master's Degrees} % -----------------------------
 

--- a/template/config.tex
+++ b/template/config.tex
@@ -22,7 +22,7 @@
 
 % Hyperlink setup -------------------------------------------------------------
 
-\hypersetup{colorlinks=false,linkcolor=black,urlcolor=black,citecolor=black}
+\hypersetup{colorlinks=true,allcolors=black}
 
 % Page setup ------------------------------------------------------------------
 

--- a/template/config.tex
+++ b/template/config.tex
@@ -5,10 +5,13 @@
 \usepackage{amscd}              % Write mathematics.
 \usepackage{amsmath}            % Write mathematics.
 \usepackage{amsthm}             % Write mathematics.
-\usepackage{cleveref}           % Make references with \cref{}.
 \usepackage{graphicx}           % Include figures from external files.
 \usepackage{lmodern}            % Handle font sizes.
 \usepackage{makeidx}            % For making an index.
+
+\usepackage[pdftex,bookmarksnumbered]{hyperref}           % Embed hyperlinks in the PDF.
+\usepackage{cleveref}           % Make references with \cref{}.
+% NOTE: hyperref must be imported BEFORE cleveref.
 
 % Optional packages.
 % \usepackage{draftwatermark}   % "DRAFT" watermark in background.
@@ -17,6 +20,10 @@
 \usepackage{layout}             % Draw the page layout with \layout*.
 \usepackage{url}                % Typesetting URLs.
 \usepackage{verbatim}           % Quote block of text verbatim.
+
+% Hyperlink setup -------------------------------------------------------------
+
+\hypersetup{colorlinks=false,linkcolor=black,urlcolor=black,citecolor=black}
 
 % Page setup ------------------------------------------------------------------
 

--- a/template/config.tex
+++ b/template/config.tex
@@ -1,24 +1,24 @@
 % Imports ---------------------------------------------------------------------
 
 % Required packages.
-\usepackage{amsfonts}           % Write mathematics.
-\usepackage{amscd}              % Write mathematics.
-\usepackage{amsmath}            % Write mathematics.
-\usepackage{amsthm}             % Write mathematics.
-\usepackage{graphicx}           % Include figures from external files.
-\usepackage{lmodern}            % Handle font sizes.
-\usepackage{makeidx}            % For making an index.
-\usepackage{hyperref}           % Embed hyperlinks in the PDF.
-\usepackage{cleveref}           % Make references with \cref{}.
+\usepackage{amsfonts}               % Write mathematics.
+\usepackage{amscd}                  % Write mathematics.
+\usepackage{amsmath}                % Write mathematics.
+\usepackage{amsthm}                 % Write mathematics.
+\usepackage{graphicx}               % Include figures from external files.
+\usepackage{lmodern}                % Handle font sizes.
+\usepackage{makeidx}                % For making an index.
+\usepackage{hyperref}               % Embed hyperlinks in the PDF.
+\usepackage[nameinlink]{cleveref}   % Make references with \cref{}.
 % NOTE: hyperref must be imported BEFORE cleveref.
 
 % Optional packages.
-% \usepackage{draftwatermark}   % "DRAFT" watermark in background.
+% \usepackage{draftwatermark}       % "DRAFT" watermark in background.
 
 % Packages used solely for the explanation in the template.
-\usepackage{layout}             % Draw the page layout with \layout*.
-\usepackage{url}                % Typesetting URLs.
-\usepackage{verbatim}           % Quote block of text verbatim.
+\usepackage{layout}                 % Draw the page layout with \layout*.
+\usepackage{url}                    % Typesetting URLs.
+\usepackage{verbatim}               % Quote block of text verbatim.
 
 % Hyperlink setup -------------------------------------------------------------
 

--- a/template/config.tex
+++ b/template/config.tex
@@ -8,8 +8,7 @@
 \usepackage{graphicx}           % Include figures from external files.
 \usepackage{lmodern}            % Handle font sizes.
 \usepackage{makeidx}            % For making an index.
-
-\usepackage[pdftex,bookmarksnumbered]{hyperref}           % Embed hyperlinks in the PDF.
+\usepackage{hyperref}           % Embed hyperlinks in the PDF.
 \usepackage{cleveref}           % Make references with \cref{}.
 % NOTE: hyperref must be imported BEFORE cleveref.
 


### PR DESCRIPTION
Added `hyperref` package back in so that `\cref{}`, `\ref{}`, and `\url{}` all create clickable links.

**NOTE**: [`hyperref` needs to be imported _before_ `cleveref`](https://tex.stackexchange.com/questions/1863/which-packages-should-be-loaded-after-hyperref-instead-of-before).
This is noted in `config.tex`.