### PR TITLE
Fix Appendix References

### DIFF
--- a/template/appendix-contributing.tex
+++ b/template/appendix-contributing.tex
@@ -7,5 +7,7 @@ This template is hosted at the following GitHub repository:
 \index{template!latest version}
 To make contributions, please fork the repository and make a pull request to the \texttt{main} branch.
 Pull requests must pass the automated GitHub action for building this report with \texttt{latexmk} before changes can be merged.
+Please record any problems or bugs with the template by \href{https://github.com/shanemcq18/utexas-thesis-template/issues/new/choose}{submitting an issue}.
+Thank you for contributing!
 \index{GitHub}
 \index{template!contributing}

--- a/template/appendix-tips.tex
+++ b/template/appendix-tips.tex
@@ -1,6 +1,8 @@
 \chapter{Tips and Tricks}
 \label{appendix:tips}
 
+This appendix lists a few considerations for modifying the template.
+
 \begin{itemize}
 \item The margin dimensions are set at the top of \texttt{utdiss.tex}. If you decide to change them, add \verb"\usepackage{layout}" to \texttt{config.tex} and use the \verb"\layout*" command in the body of the document to see a schematic of the page setup.
 See \Cref{figure:layout}.
@@ -17,6 +19,9 @@ Use \verb"\Cref{}" if you want to ensure that the first word is capitalized (e.g
     &= \mathbf{F}(\widehat{\mathbf{q}}(t), \mathbf{u}(t)).
 \end{align}
 To change how this looks, play with the \verb"\numberwithin{}{}" command in \texttt{config.tex} \textbf{and} the \verb"\numberwithin{}{}" command in \texttt{utdiss.sty} under \verb"\def\appendices".
+
+\item The style of theorems, remarks, definitions, and so on is dictated by \verb"\theoremstyle{}" in \texttt{config.tex}.
+If you change the theorem style and have appendices, you may also have to change the \verb"\theoremstyle{}`" in \texttt{utdiss.sty} under \verb"\def\appendices".
 \end{itemize}
 
 \newpage

--- a/template/chapter-examples.tex
+++ b/template/chapter-examples.tex
@@ -19,6 +19,7 @@ Here are some equations using the \texttt{align} environment.
     &= \frac{-b + \sqrt{b^{2} - 4ac}}{2a}
 \end{align}
 \index{environments!align@\verb+align+}
+You can refer to equations, like \cref{eq:quadratic}, with \verb+\cref{}+.
 
 The configuration file \texttt{config.tex} defines the following ``theorem'' environments.
 \begin{itemize}

--- a/template/config.tex
+++ b/template/config.tex
@@ -33,7 +33,7 @@
 
 % Math environments -----------------------------------------------------------
 
-\theoremstyle{plain}
+\theoremstyle{plain}        % If changed, also change line 280 of utdiss.sty.
 \newtheorem{theorem}{Theorem}[chapter]                  % Number by chapter
 \newtheorem{corollary}[theorem]{Corollary}
 \newtheorem{lemma}[theorem]{Lemma}
@@ -48,6 +48,6 @@
 
 % Number equations by chapter (Theorem 2.1, 2.2, ...).
 \numberwithin{equation}{chapter}
-\crefformat{equation}{(#2#1#3)}
+\crefformat{equation}{#2(#1)#3}
 
 % Other customizations --------------------------------------------------------

--- a/template/utdiss.sty
+++ b/template/utdiss.sty
@@ -265,12 +265,21 @@
 
     \addcontentsline{toc}{chapter}{Appendices}
 
-    \setcounter{chapter}{0}
     \setcounter{section}{0}
+    \renewcommand{\theappendix}{\Alph{appendix}}
     \def\@chapapp{\appendixname}
     \chap@or@app=2
-    \def\thechapter{\Alph{chapter}}
-    \numberwithin{equation}{chapter}              % Equations (A.1), (A.2), ...
+    \def\thechapter{\Alph{appendix}}              % Appendix A, B, ...
+    \numberwithin{equation}{appendix}             % Equations (A.1), (A.2), ...
+    \numberwithin{figure}{appendix}
+
+    \makeatletter
+    \expandafter\let\csname theorem\endcsname\relax
+    \expandafter\let\csname c@theorem\endcsname\relax
+    \makeatother
+    \theoremstyle{plain}
+    \newtheorem{theorem}{Theorem}[appendix]       % Number by theorems by appdx
+
 }
 
 % Counters --------------------------------------------------------------------
@@ -302,6 +311,8 @@
 
 \newcounter{no@chapters}
 \setcounter{no@chapters}{0}
+\newcounter{appendix}
+\setcounter{appendix}{0}
 
 \newcommand\nochapters{
     \setcounter{no@chapters}{1}
@@ -324,7 +335,11 @@
 }
 
 \def\@chapter[#1]#2{\ifnum \c@secnumdepth >\m@ne
-    \refstepcounter{chapter}
+    \ifnum\chap@or@app=1
+        \refstepcounter{chapter}
+    \fi\ifnum\chap@or@app=2
+        \refstepcounter{appendix}
+    \fi
     \typeout{\@chapapp\space\thechapter.}
     \addcontentsline{toc}{chapter}{\@chapapp\space\thechapter.\hspace*{1em}#1}\else
     \addcontentsline{toc}{chapter}{#1}\fi


### PR DESCRIPTION
This PR mostly solves #3, so now appendix references actually point to the appendix.

The only outstanding problem is referring to sections of an appendix points to the body. Example:

```latex
\appendices
\chapter{My Appendix}

\section{My Section}
\label{sec:appendix:mysection}
```

Referring to `mysection` with `\cref{mysection}` will point you to section 1 of chapter 2 in the body.