### PR TITLE
Add support for parts, fix default hyperref import

### DIFF
--- a/template/appendix-tips.tex
+++ b/template/appendix-tips.tex
@@ -15,10 +15,12 @@ Use \verb"\Cref{}" if you want to ensure that the first word is capitalized (e.g
 
 \item This is how a labeled equation looks in an appendix:
 \begin{align}
-    \frac{\textup{d}}{\textup{d}t}\widehat{\mathbf{q}}(t)
-    &= \mathbf{F}(\widehat{\mathbf{q}}(t), \mathbf{u}(t)).
+    \label{eq:appendix:example}
+    \frac{\textup{d}}{\textup{d}t}\mathbf{q}(t)
+    &= \mathbf{F}(\mathbf{q}(t), \mathbf{u}(t)).
 \end{align}
 To change how this looks, play with the \verb"\numberwithin{}{}" command in \texttt{config.tex} \textbf{and} the \verb"\numberwithin{}{}" command in \texttt{utdiss.sty} under \verb"\def\appendices".
+We can reference the equation with \verb"\cref{}", which produces \cref{eq:appendix:example} in this case.
 
 \item The style of theorems, remarks, definitions, and so on is dictated by \verb"\theoremstyle{}" in \texttt{config.tex}.
 If you change the theorem style and have appendices, you may also have to change the \verb"\theoremstyle{}`" in \texttt{utdiss.sty} under \verb"\def\appendices".

--- a/template/chapter-usage.tex
+++ b/template/chapter-usage.tex
@@ -182,6 +182,20 @@ This way, the next chunk of \texttt{main.tex} will then looks something like thi
 \end{verbatim}
 \index{commands!include@\verb+\include{}+}%
 
+Chapters can also be grouped into parts with the \verb+\part{}+ command.
+For example,
+\texttt{main.tex}
+\begin{verbatim}
+    \part{Background}
+    \include{chapter-introduction}
+    \part{Results}
+    \include{chapter-usage}
+    \include{chapter-examples}
+    \part{Discussion}
+    \include{chapter-conclusion}
+\end{verbatim}
+\index{commands!part@\verb+\part{}+}%
+
 \subsection{Chapters} % -------------------------------------------------------
 
 The beginning of each chapter file should begin with a \verb+\chapter[]{}+

--- a/template/config.tex
+++ b/template/config.tex
@@ -15,14 +15,14 @@
 % Optional packages.
 % \usepackage{draftwatermark}       % "DRAFT" watermark in background.
 
-% Packages used solely for the explanation in the template.
+% Packages used for the explanation in the template.
 \usepackage{layout}                 % Draw the page layout with \layout*.
 \usepackage{url}                    % Typesetting URLs.
 \usepackage{verbatim}               % Quote block of text verbatim.
 
 % Hyperlink setup -------------------------------------------------------------
 
-\hypersetup{colorlinks=true,allcolors=black}
+\hypersetup{hypertexnames=false,colorlinks=true,allcolors=black}
 
 % Page setup ------------------------------------------------------------------
 
@@ -33,8 +33,8 @@
 
 % Math environments -----------------------------------------------------------
 
-\theoremstyle{plain}        % If changed, also change line 280 of utdiss.sty.
-\newtheorem{theorem}{Theorem}[chapter]                  % Number by chapter
+\theoremstyle{plain}        % If changed, also change line 294 of utdiss.sty.
+\newtheorem{theorem}{Theorem}[chapter]                  % Number by chapter.
 \newtheorem{corollary}[theorem]{Corollary}
 \newtheorem{lemma}[theorem]{Lemma}
 \newtheorem{proposition}[theorem]{Proposition}

--- a/template/main.tex
+++ b/template/main.tex
@@ -88,7 +88,11 @@ A short dedication to someone special.
 
 % CHAPTERS --------------------------------------------------------------------
 
+% \part{Usage}
+
 \include{chapter-usage}
+
+% \part{Examples}
 
 \include{chapter-examples}
 

--- a/template/utdiss.sty
+++ b/template/utdiss.sty
@@ -266,10 +266,18 @@
         \markboth{}{}\pagestyle{myheadings}
         \thispagestyle{plain}
     \vspace*{\fill}
-    \centerline{\large\bf Appendices}
+    \ifhasparts
+        \centerline{\huge\bf Appendices}
+    \else
+        \centerline{\large\bf Appendices}
+    \fi
     \vspace*{\fill}
 
-    \addcontentsline{toc}{chapter}{Appendices}
+    \ifhasparts
+        \addcontentsline{toc}{part}{Appendices}
+    \else
+        \addcontentsline{toc}{chapter}{Appendices}
+    \fi
 
     \setcounter{section}{0}
     \renewcommand{\theappendix}{\Alph{appendix}}
@@ -288,9 +296,13 @@
 }
 
 % Counters --------------------------------------------------------------------
+\newif\ifhasparts
+\haspartsfalse
+
 % Redefinition of \@part for using by \part
 \newcount\with@parts\with@parts=0
 \def\@part[#1]#2{%
+    \haspartstrue
     \short@page
     \ifnum \c@secnumdepth >-2 \relax
         \refstepcounter{part}


### PR DESCRIPTION
Added a `\part{}` command for separating chapters into parts. Also changes the `hyperref` setup to the fix mentioned in #3.